### PR TITLE
Gets the RUPFC testmerge ready

### DIFF
--- a/_maps/shuttles/nanotrasen/nanotrasen_harrier.dmm
+++ b/_maps/shuttles/nanotrasen/nanotrasen_harrier.dmm
@@ -7336,6 +7336,7 @@
 /obj/item/aicard,
 /obj/item/mmi/posibrain,
 /obj/item/aiModule/reset/purge,
+/obj/item/organ/brain/cybernetic/ai,
 /turf/open/floor/circuit,
 /area/ship/science/ai_chamber)
 "NS" = (

--- a/_maps/shuttles/nanotrasen/nanotrasen_ranger.dmm
+++ b/_maps/shuttles/nanotrasen/nanotrasen_ranger.dmm
@@ -5854,6 +5854,7 @@
 	amount = 25
 	},
 /obj/item/aicard,
+/obj/item/organ/brain/cybernetic/ai,
 /turf/open/floor/circuit/telecomms,
 /area/ship/science/ai_chamber)
 "OC" = (

--- a/code/modules/cargo/packs/machinery.dm
+++ b/code/modules/cargo/packs/machinery.dm
@@ -209,6 +209,8 @@
 	crate_name = "robotics assembly crate"
 	crate_type = /obj/structure/closet/crate/science
 	no_bundle = TRUE
+	faction = /datum/faction/nt
+	faction_locked = TRUE
 
 /datum/supply_pack/machinery/remoteipc
 	name = "Remote Uplink Postironic Frame Controller Kit"

--- a/code/modules/cargo/packs/machinery.dm
+++ b/code/modules/cargo/packs/machinery.dm
@@ -210,6 +210,14 @@
 	crate_type = /obj/structure/closet/crate/science
 	no_bundle = TRUE
 
+/datum/supply_pack/machinery/remoteipc
+	name = "Remote Uplink Postironic Frame Controller Kit"
+	desc = "Contains a NanoTrasen brand R.U.P.F.C." //TODO: get ratvarr to rewrite this
+	cost = 1250 //TODO: get ratvarr to reprice this
+	contains = list(/obj/item/organ/brain/cybernetic/ai)
+	crate_name = "remote chassis crate"
+	crate_type = /obj/structure/closet/crate/science
+
 /*
 		Miscellaneous machines
 */

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -290,7 +290,7 @@ Works together with spawning an observer, noted above.
 			return ghost
 	if(key)
 		if(key[1] != "@") // Skip aghosts.
-			if(HAS_TRAIT(src, TRAIT_CORPSELOCKED))
+			if(HAS_TRAIT(src, TRAIT_CORPSELOCKED) && !isAdminObserver(src))
 				if(can_reenter_corpse) //If you can re-enter the corpse you can't leave when corpselocked
 					return
 			stop_sound_channel(CHANNEL_HEARTBEAT) //Stop heartbeat sounds because You Are A Ghost Now

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1371,5 +1371,8 @@
 /mob/living/carbon/human/species/ipc
 	race = /datum/species/ipc
 
+/mob/living/carbon/human/species/ipc/frame
+	race = /datum/species/ipc/frame
+
 /mob/living/carbon/human/species/lizard/ashwalker/kobold
 	race = /datum/species/lizard/ashwalker/kobold

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -63,7 +63,7 @@
 	)
 
 /datum/species/ipc/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load) // Let's make that IPC actually robotic.
-	if(C.dna?.features["ipc_brain"] == "Man-Machine Interface")
+	if(C.dna?.features["ipc_brain"] == "Man-Machine Interface" && (mutantbrain != /obj/item/organ/brain/cybernetic/ai))
 		mutantbrain = /obj/item/organ/brain/mmi_holder
 	. = ..()
 	if(ishuman(C))
@@ -287,3 +287,6 @@
 /mob/living/carbon/proc/charge(datum/source, amount, repairs)
 	if(nutrition < NUTRITION_LEVEL_WELL_FED)
 		adjust_nutrition(amount / 10) // The original amount is capacitor_rating*100
+
+/datum/species/ipc/frame
+	mutantbrain = /obj/item/organ/brain/cybernetic/ai

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1176,7 +1176,7 @@
 	return TRUE
 
 /obj/item/organ/brain/cybernetic/ai
-	name = "Remote uplink positronic frame controller"
+	name = "remote uplink positronic frame controller"
 	desc = "Can be inserted into an I.P.C. without a controlling positronic brain to allow stationary positronic interface cores to control it."
 	icon = 'icons/obj/assemblies.dmi' ///so its not a fucking brain
 	icon_state = "posibrain"
@@ -1288,7 +1288,7 @@
 	if(mainframe.laws)
 		mainframe.laws.show_laws(mainframe)
 	if(mainframe.eyeobj)
-		mainframe.eyeobj.setLoc(loc)
+		mainframe.eyeobj.setLoc(get_turf(owner))
 	mainframe = null
 	update_med_hud_status(owner)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes some bugs with the camera and corpselock, adds the RUPFC to cargo for 1250 credits.
Also adds an IPC subtype /mob/living/carbon/human/species/ipc/frame which spawns with an RUPFC instead of the usual brain, for use in testing (doing ipc surgery steps every time I wanted to test drove me insane).

TODO:
- The RUPFC isn't actually a camera source right now. I'm working on a PR to fix bodycams, and I'll get around to making RUPFC-enabled IPCs a camera source as well.
- The behavior when an AI takes over an IPC another AI is using is **untested.** (i couldn't get someone else on to figure this out)
- Disconnect still has no icon
- The device still uses the positronic brain icon, it should probably be subtly different?
- Getting IPC chassis still might be an issue, but thgvr has said that this should be more as an "alternate species" to IPC i.e. you have an IPC crewmate volunteer to be an AI, at which point they're a crewmate who happens to have a centralized core. Probably. People might still powergame hermit IPCs (horrifying).
- oh yeah thgvr also wanted an ssd icon
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

